### PR TITLE
Update Invoke-JiraMethod.ps1

### DIFF
--- a/PSJira/Functions/Internal/Invoke-JiraMethod.ps1
+++ b/PSJira/Functions/Internal/Invoke-JiraMethod.ps1
@@ -90,7 +90,7 @@ function Invoke-JiraMethod
             Write-Debug "[Invoke-JiraMethod] Retrieved body of HTTP response for more information about the error (`$body)"
             $result = ConvertFrom-Json -InputObject $body
         } else {
-            $result = ConvertFrom-Json -InputObject $webResponse
+            $result = ConvertFrom-Json -InputObject $webResponse.content
         }
 
         if ($result.errors -ne $null)


### PR DESCRIPTION
This change helps prevent ConvertFrom-Json breaking text encoding when processing objects returned from Invoke-WebRequest. This worked in my tests, but would appreciate review.